### PR TITLE
AWS: Development to Production

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,7 +33,7 @@
             Prescription labels can be hard to see. <strong>See My Pills</strong> helps you medicate with confidence.
             <br>Click below to share or take a photo, and we will help you see and hear it.
         </p>
-        <a href="/src/pages/upload-bottle.html" class="cta-blue">Start Medication Scan</a>
+        <a href="/upload-bottle.html" class="cta-blue">Start Medication Scan</a>
     </main>
 
 </body>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/node": "^22.0.0",
     "eslint": "^10.4.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.60.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.1)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.21
       eslint:
         specifier: ^10.4.1
         version: 10.4.1
@@ -29,10 +32,10 @@ importers:
         version: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
       vite:
         specifier: ^8.0.12
-        version: 8.0.16
+        version: 8.0.16(@types/node@22.19.21)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(vite@8.0.16)
+        version: 4.1.8(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21))
 
 packages:
 
@@ -237,6 +240,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@typescript-eslint/eslint-plugin@8.60.1':
     resolution: {integrity: sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==}
@@ -728,6 +734,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
@@ -988,6 +997,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@22.19.21':
+    dependencies:
+      undici-types: 6.21.0
+
   '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -1088,13 +1101,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16)':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.21))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16
+      vite: 8.0.16(@types/node@22.19.21)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1473,11 +1486,13 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  undici-types@6.21.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite@8.0.16:
+  vite@8.0.16(@types/node@22.19.21):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1485,12 +1500,13 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 22.19.21
       fsevents: 2.3.3
 
-  vitest@4.1.8(vite@8.0.16):
+  vitest@4.1.8(@types/node@22.19.21)(vite@8.0.16(@types/node@22.19.21)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.21))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -1507,8 +1523,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16
+      vite: 8.0.16(@types/node@22.19.21)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.21
     transitivePeerDependencies:
       - msw
 

--- a/frontend/public/components/layout/header.html
+++ b/frontend/public/components/layout/header.html
@@ -6,7 +6,7 @@
         <a href="/index.html" class="cta-yellow" aria-label="Go to homepage: See My Pills">See My Pills</a>
       </li>
       <li>
-        <a href="/src/pages/upload-bottle.html" class="cta-yellow" aria-label="Upload your prescription pill bottle for analysis">Upload Bottle</a>
+        <a href="/upload-bottle.html" class="cta-yellow" aria-label="Upload your prescription pill bottle for analysis">Upload Bottle</a>
       </li>
       <li>
         <a href="https://github.com/barronbytes/seemypills" class="cta-yellow" aria-label="View project on GitHub" target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/frontend/src/core/component-loader.ts
+++ b/frontend/src/core/component-loader.ts
@@ -23,13 +23,8 @@ class ComponentLoader extends HTMLElement {
       .catch(err => {
         console.error(`ComponentLoader error (${src}):`, err);
         
-        // 1. Check if the app is running locally in development mode
-        if (import.meta.env.DEV) {
-          window.location.href = '/src/pages/404.html';
-        } else {
-          // 2. Fall back to the flat root layout when deployed live on AWS production
-          window.location.href = '/404.html';
-        }
+        // both development and production fall back to root entry point
+        window.location.href = '/404.html';
       });
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,36 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
+import type { Connect } from 'vite';
 
 export default defineConfig({
   root: '.', // Keeps the root directory as frontend/
+  
+  // Configure the development server to map production paths back to source paths
+  server: {
+    open: true,
+    proxy: {}, // Placeholder if you need to bypass backend API cors later
+  },
+  
+  // Force Vite to treat this as a true Multi-Page Application (MPA) in development
+  appType: 'mpa', 
+
+  // Add a dev-only routing rewrite rule using standard Vite server configuration middleware
+  plugins: [
+    {
+      name: 'local-html-page-rewrites',
+      configureServer(server) {
+        // Rewrites the clean production path to the actual source file location during local testing
+        const rewriteUploadBottlePath: Connect.NextHandleFunction = (req, _res, next) => {
+          if (req.url === '/upload-bottle.html') {
+            req.url = '/src/pages/upload-bottle.html';
+          }
+          next();
+        };
+
+        server.middlewares.use(rewriteUploadBottlePath);
+      },
+    },
+  ],
+
   test: {
     env: {
       VITE_API_BASE_URL: 'http://localhost:8000',
@@ -10,10 +39,16 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
-        // 1. Define every physical HTML page as an explicit entry point using standard URL paths
+        // Map entry keys to explicit root-level output endpoints
         main: new URL('index.html', import.meta.url).pathname,
-        notFound: new URL('404.html', import.meta.url).pathname,
-        uploadBottle: new URL('src/pages/upload-bottle.html', import.meta.url).pathname,
+        '404': new URL('404.html', import.meta.url).pathname,
+        'upload-bottle': new URL('src/pages/upload-bottle.html', import.meta.url).pathname,
+      },
+      output: {
+        // Ensure compiled HTML structures flatten into clean asset targets
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash].[ext]',
       },
     },
   },


### PR DESCRIPTION
Changes required to move from SPA to MPA:

1. Update dependencies
2. Move HTML fragments loaded by component loader to `/public/` folder
3. Remove local page links and use development page links instead (the `/dist/` folder flattens all page links found locally)
4. Update component loader logic (catch logic improved)
5. Update vite config file (MPA enabled, middleware, outputs)