### PR TITLE
AWS: HTML Page Flattening

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,11 +35,14 @@ export default defineConfig({
       enforce: 'post',
       // Relocates built HTML pages from src/pages/ to the dist root so production paths stay clean
       generateBundle(_options, bundle) {
-        for (const fileName in bundle) {
-          if (fileName.startsWith('src/pages/')) {
-            const flattenedFileName = fileName.replace('src/pages/', '');
-            bundle[fileName].fileName = flattenedFileName;
-            bundle[flattenedFileName] = bundle[fileName];
+        for (const fileName of Object.keys(bundle)) {
+          const file = bundle[fileName];
+          if (fileName.startsWith('src/pages/') && file.type === 'asset') {
+            this.emitFile({
+              type: 'asset',
+              fileName: fileName.replace('src/pages/', ''),
+              source: file.source,
+            });
             delete bundle[fileName];
           }
         }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
     },
     {
       name: 'flatten-page-html-output',
+      // Runs after vite:build-html (which emits HTML into the bundle) so the entries exist to rename
+      enforce: 'post',
       // Relocates built HTML pages from src/pages/ to the dist root so production paths stay clean
       generateBundle(_options, bundle) {
         for (const fileName in bundle) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   // Force Vite to treat this as a true Multi-Page Application (MPA) in development
   appType: 'mpa', 
 
-  // Add a dev-only routing rewrite rule using standard Vite server configuration middleware
+  // Vite plugins: dev-only routing rewrite, plus build-time HTML output flattening
   plugins: [
     {
       name: 'local-html-page-rewrites',
@@ -27,6 +27,20 @@ export default defineConfig({
         };
 
         server.middlewares.use(rewriteUploadBottlePath);
+      },
+    },
+    {
+      name: 'flatten-page-html-output',
+      // Relocates built HTML pages from src/pages/ to the dist root so production paths stay clean
+      generateBundle(_options, bundle) {
+        for (const fileName in bundle) {
+          if (fileName.startsWith('src/pages/')) {
+            const flattenedFileName = fileName.replace('src/pages/', '');
+            bundle[fileName].fileName = flattenedFileName;
+            bundle[flattenedFileName] = bundle[fileName];
+            delete bundle[fileName];
+          }
+        }
       },
     },
   ],


### PR DESCRIPTION
## 🧾 Description

Updated Vite config file to use emitFile for HTML page flattening (Rolldown compatability). This will allow future pulls from remote `main` to ubuntu EC2 `main` branch to sync without manually fixing file paths as previously done.

## 🔀 Type of Change

- [ ] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## 🧪 How Has This Been Tested?

Not applicable.

## ✅ Checklist

- [ ] Performed a self-review of code
- [ ] Followed style guidelines for project
- [ ] Commented code where necessary
- [ ] New and existing tests pass locally
- [ ] Documentation updated

## 🔗 Related Issues

Not applicable.