### PR TITLE
Backend: Export PATH added to CD script for UV access

### DIFF
--- a/scripts/cd-main-update-deploy.sh
+++ b/scripts/cd-main-update-deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Non-interactive SSH shells don't source ~/.bashrc, so add uv's install location explicitly
+export PATH="$HOME/.local/bin:$PATH"
+
 echo "🚀 Starting automated deployment for SeeMyPills..."
 
 # Ensure in root repository directory


### PR DESCRIPTION
## 🧾 Description

GitHub Action for CD pipeline failed on backend workflow. Problem of `uv` command not found. To resolve this PR introduced an export PATH to CD script for access to `uv` command.

## 🔀 Type of Change

- [ ] New feature
- [x] Refactor
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## 🧪 How Has This Been Tested?

Not applicable.

## ✅ Checklist

- [x] Performed a self-review of code
- [x] Followed style guidelines for project
- [X] Commented code where necessary
- [x] New and existing tests pass locally
- [x] Documentation updated

## 🔗 Related Issues

Not applicable.