### PR TITLE
Backend (CI/CD): Development to Production

### DIFF
--- a/scripts/cd-main-update-deploy.sh
+++ b/scripts/cd-main-update-deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Non-interactive SSH shells don't source ~/.bashrc, so add uv's install location explicitly
+export PATH="$HOME/.local/bin:$PATH"
+
 echo "🚀 Starting automated deployment for SeeMyPills..."
 
 # Ensure in root repository directory


### PR DESCRIPTION
GitHub Action for CD pipeline failed on backend workflow. Problem of `uv` command not found. To resolve this PR introduced an export PATH to CD script for access to `uv` command.